### PR TITLE
Update .gitignore since we need the *.xcodeproj files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,10 +39,10 @@ playground.xcworkspace
 # Swift Package Manager
 #
 # Add this line if you want to avoid checking in source code from Swift Package Manager dependencies.
-Packages/
-Package.pins
-Package.resolved
-*.xcodeproj
+# Packages/
+# Package.pins
+# Package.resolved
+# *.xcodeproj
 #
 # Xcode automatically generates this directory with a .xcworkspacedata file and xcuserdata
 # hence it is not needed unless you have added a package configuration file to your project


### PR DESCRIPTION
.xcodeproj is needed by xcode to create references to files so it can't be in the gitignore